### PR TITLE
feat: create both rootless and rootfull images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.20.1
 COPY --from=prom/node-exporter:v1.8.1 /bin/node_exporter /usr/local/bin/
 COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
+RUN apk add --update bash coreutils
+
 COPY bin ./bin
 COPY monitor ./monitor
 COPY dind-metrics ./dind-metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,13 @@
-ARG ARCH=amd64
+FROM alpine:3.20.1
 
-FROM prom/node-exporter:v1.6.1 AS node-exporter
-
-FROM alpine:3.16.7
-
-COPY --from=node-exporter /bin/node_exporter /bin/
-
-ENV KUBECTL_VERSION="v1.8.8"
-
-RUN apk add --update curl bash coreutils \
-    && export ARCH=$([[ "$(uname -m)" == "aarch64" ]] && echo "arm64" || echo "amd64") \
-    && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl -o /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
-
-# add user
-RUN addgroup --gid 1000 dind-volume-utils && \
-    adduser --uid 1000 --gecos "" --disabled-password \
-    --ingroup dind-volume-utils \
-    --home /home/dind-volume-utils \
-    --shell /bin/bash dind-volume-utils
+COPY --from=prom/node-exporter:v1.8.1 /bin/node_exporter /usr/local/bin/
+COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
 WORKDIR /home/dind-volume-utils
 
-ADD bin ./bin
-ADD monitor ./monitor
-ADD dind-metrics ./dind-metrics
-ADD local-volumes ./local-volumes
+COPY bin ./bin
+COPY monitor ./monitor
+COPY dind-metrics ./dind-metrics
+COPY local-volumes ./local-volumes
 
-RUN chown -R dind-volume-utils:dind-volume-utils /home/dind-volume-utils && \
-    chmod 755 /home/dind-volume-utils
-
-USER dind-volume-utils:dind-volume-utils
-
-CMD ["/bin/bash"]
+CMD ["sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/b
 
 RUN apk add --update bash coreutils
 
+WORKDIR /home/dind-volume-utils
+
 COPY bin ./bin
 COPY monitor ./monitor
 COPY dind-metrics ./dind-metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM alpine:3.20.1
 COPY --from=prom/node-exporter:v1.8.1 /bin/node_exporter /usr/local/bin/
 COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
-WORKDIR /home/dind-volume-utils
-
 COPY bin ./bin
 COPY monitor ./monitor
 COPY dind-metrics ./dind-metrics

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -3,6 +3,8 @@ FROM alpine:3.20.1
 COPY --from=prom/node-exporter:v1.8.1 /bin/node_exporter /usr/local/bin/
 COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 
+RUN apk add --update bash coreutils
+
 WORKDIR /home/dind-volume-utils
 
 COPY bin ./bin

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,0 +1,25 @@
+FROM alpine:3.20.1
+
+COPY --from=prom/node-exporter:v1.8.1 /bin/node_exporter /usr/local/bin/
+COPY --from=bitnami/kubectl:1.30.2 /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+
+WORKDIR /home/dind-volume-utils
+
+COPY bin ./bin
+COPY monitor ./monitor
+COPY dind-metrics ./dind-metrics
+COPY local-volumes ./local-volumes
+
+# add user
+RUN addgroup --gid 1000 dind-volume-utils && \
+    adduser --uid 1000 --gecos "" --disabled-password \
+    --ingroup dind-volume-utils \
+    --home /home/dind-volume-utils \
+    --shell /bin/bash dind-volume-utils
+
+RUN chown -R dind-volume-utils:dind-volume-utils /home/dind-volume-utils && \
+    chmod 755 /home/dind-volume-utils
+
+USER dind-volume-utils:dind-volume-utils
+
+CMD ["sh"]

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.29.5
+version: 1.30.0


### PR DESCRIPTION
## What
copied the current dockerfile into Dockerfile.rootless
removed rootless lines from Dockerfile

also updated node-exporter, and kubectl, and got kubectl from bitnami image instead of using curl.

## Why
we need to have rootless and rootfull dind-volume-utils, to match the rootless/full state of the dind pod

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
